### PR TITLE
Fix README typos, add VimFormatter for RSpec 3

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,12 +10,16 @@ This repo is more of a how-to, than packaged sofware.  Imma show you how to do i
 **In your shell:**
 ```bash
 # Setup the spec formatter, so VIM can read rspec's output:
-cp spec/support/formatters/VIM_formatter.rb YOURREPO/spec/support/formatters/vim_formatter.rb
+# for RSpec 2:
+cp spec/support/formatters/vim_formatter.rb YOURREPO/spec/support/formatters/vim_formatter.rb
+
+# for RSpec 3:
+cp spec/support/formatters/vim_formatter_rspec3.rb YOURREPO/spec/support/formatters/vim_formatter.rb
 
 # Run rspec with the formatter, and put the output where VIM can get it.
 # (rspec lets you specify more than one formatter, so we still get nice
 # documentation/progress output too! )
-rspec --require=support/formatters/VIM_formatter.rb --format VimFormatter --out quickfix.out  --format progress
+rspec --require=support/formatters/vim_formatter.rb --format VimFormatter --out quickfix.out  --format progress
 
 # `quickfix.out` now has the VIM-friendly spec output.
 ```
@@ -45,7 +49,7 @@ Yea, this works with Guard too, cause @mikegee loves guard.
 # Requires guard >= 2.0.0
 
 rspec_quick =  ' rspec '
-rspec_quick << ' --require=support/formatters/VIM_formatter.rb '
+rspec_quick << ' --require=support/formatters/vim_formatter.rb '
 rspec_quick << ' --format VimFormatter '
 rspec_quick << ' --out quickfix.out '
 rspec_quick << ' --format progress '
@@ -59,7 +63,7 @@ end
 I generally dislike extensive extra-app tooling like guard.  I also dislike leaving VIM to run rspec.  So, lets map the mother of all leader commands:
 ```
 # Run the specs, and open the updated quickfix on `<leader>s`
-:map <leader>s :call system('rspec --require=support/formatters/VIM_formatter.rb --format VimFormatter --out quickfix.out  --format progress') \| cg quickfix.out \| cwindow
+:map <leader>s :call system('rspec --require=support/formatters/vim_formatter.rb --format VimFormatter --out quickfix.out  --format progress') \| cg quickfix.out \| cwindow
 
 # or, without the temp file:
 :map <leader>s :cgete system('rspec --require=support/formatters/vim_formatter.rb --format VimFormatter') \| cwindow

--- a/spec/support/formatters/vim_formatter_rspec3.rb
+++ b/spec/support/formatters/vim_formatter_rspec3.rb
@@ -1,0 +1,22 @@
+# Adapted from https://github.com/bronson/vim-runtest/blob/master/rspec_formatter.rb.
+# Adopted to RSpec ~> 3 from spec/support/formatters/vim_formatter.rb
+require 'rspec/core/formatters/base_text_formatter'
+
+class VimFormatter
+  RSpec::Core::Formatters.register self, :example_failed
+
+  def initialize(output)
+    @output = output
+  end
+
+  def example_failed(notification)
+    @output << format(notification) + "\n"
+  end
+
+  private
+
+  def format(notification)
+    rtn = "%s: %s" % [notification.example.location, notification.exception.message]
+    rtn.gsub("\n", ' ')[0,80]
+  end
+end


### PR DESCRIPTION
Hi, Mark
your HOWTO helped me to setup rspec with guard today. Thank you!

I had to adopt VimFormatter to RSpec 3, and I found some typos in README. Hope that pull request helps someone else.

With best wishes!
